### PR TITLE
Fix very large thumbnails

### DIFF
--- a/assets/views/main.php
+++ b/assets/views/main.php
@@ -62,7 +62,7 @@ and you will follow all these awesome PHP people.</p>
                             <div class="media">
                                 <div class="media-left media-middle">
                                     <a href="https://twitter.com/<?=$dev['twitter']?>">
-                                        <img class="media-object" src="http://avatars.io/twitter/<?=$dev['twitter']?>?size=small">
+                                        <img class="media-object" src="http://avatars.io/twitter/<?=$dev['twitter']?>?size=small" width="100" height="100">
                                     </a>
                                 </div>
                                 <div class="media-body">


### PR DESCRIPTION
Twitter user thumbnails are very big. This fix makes them always 100px x 100px

<img width="510" alt="screen shot 2015-11-30 at 00 24 18" src="https://cloud.githubusercontent.com/assets/447973/11460635/c37c6fca-96f8-11e5-87d8-69337e91cae6.png">
